### PR TITLE
fix(tasks.json): remove cp command from build debug

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -190,7 +190,7 @@
             },
             "problemMatcher": [],
             "dependsOn": [
-                "Build app"
+                "Build app [debug]"
             ]
         },
     ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -48,7 +48,7 @@
             "label": "Build app [debug]",
             "type": "shell",
             // Builds the app with debug mode enabled using the make command, inside the docker container.
-            "command": "docker exec -it ${config:container_name} bash -c 'export BOLOS_SDK=$(echo ${input:sdk}) && make -j DEBUG=1' && cp bin/app.elf tests/elfs/klaytn_${input:model}.elf",
+            "command": "docker exec -it ${config:container_name} bash -c 'export BOLOS_SDK=$(echo ${input:sdk}) && make -j DEBUG=1'",
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
the cp command was removed from bulid debug as it generated an error. the process still works without it.